### PR TITLE
Add React app deployment infrastructure with S3 and CloudFront

### DIFF
--- a/2.iac/react_app_deploy/.gitignore
+++ b/2.iac/react_app_deploy/.gitignore
@@ -1,0 +1,7 @@
+# Terraform
+.terraform/
+*.tfstate
+*.tfstate.backup
+*.tfvars
+!*.tfvars.example
+.terraform.lock.hcl

--- a/2.iac/react_app_deploy/README.md
+++ b/2.iac/react_app_deploy/README.md
@@ -1,0 +1,57 @@
+# React App Deployment
+
+This Terraform configuration deploys a React application to AWS using S3 for static hosting and CloudFront for CDN with HTTPS.
+
+## Architecture
+
+- **S3 Bucket**: Hosts the React build files
+- **CloudFront**: CDN with HTTPS support
+- **Route 53**: Optional domain configuration
+
+## Prerequisites
+
+- AWS CLI configured
+- Terraform installed
+- Node.js and npm installed
+
+## Deployment
+
+```bash
+# Make scripts executable
+chmod +x deploy.sh destroy.sh
+
+# Deploy
+./deploy.sh
+```
+
+## Manual Steps
+
+1. Build React app:
+```bash
+cd ../../1.code/react-app
+npm install
+npm run build
+```
+
+2. Deploy infrastructure:
+```bash
+cd terraform
+terraform init
+terraform apply
+```
+
+3. Upload build files:
+```bash
+aws s3 sync ../../../1.code/react-app/build/ s3://BUCKET_NAME/ --delete
+```
+
+4. Invalidate CloudFront cache:
+```bash
+aws cloudfront create-invalidation --distribution-id DISTRIBUTION_ID --paths "/*"
+```
+
+## Cleanup
+
+```bash
+./destroy.sh
+```

--- a/2.iac/react_app_deploy/deploy.sh
+++ b/2.iac/react_app_deploy/deploy.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+set -e
+
+echo "Building React app..."
+cd ../../1.code/react-app
+npm install
+npm run build
+
+echo "Deploying infrastructure..."
+cd ../../2.iac/react_app_deploy/terraform
+terraform init
+terraform plan
+terraform apply -auto-approve
+
+echo "Getting S3 bucket name..."
+BUCKET_NAME=$(terraform output -raw s3_bucket_name)
+CLOUDFRONT_ID=$(terraform output -raw cloudfront_distribution_id)
+
+echo "Uploading React build to S3..."
+aws s3 sync ../../../1.code/react-app/dist/ s3://$BUCKET_NAME/ --delete
+
+echo "Invalidating CloudFront cache..."
+aws cloudfront create-invalidation --distribution-id $CLOUDFRONT_ID --paths "/*"
+
+echo "Deployment complete!"
+terraform output website_url

--- a/2.iac/react_app_deploy/destroy.sh
+++ b/2.iac/react_app_deploy/destroy.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+set -e
+
+cd terraform
+
+echo "Getting S3 bucket name..."
+BUCKET_NAME=$(terraform output -raw s3_bucket_name 2>/dev/null || echo "")
+
+if [ ! -z "$BUCKET_NAME" ]; then
+    echo "Emptying S3 bucket..."
+    aws s3 rm s3://$BUCKET_NAME/ --recursive
+fi
+
+echo "Destroying infrastructure..."
+terraform destroy -auto-approve
+
+echo "Cleanup complete!"

--- a/2.iac/react_app_deploy/terraform/main.tf
+++ b/2.iac/react_app_deploy/terraform/main.tf
@@ -1,0 +1,121 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+}
+
+# S3 bucket for React app hosting
+resource "aws_s3_bucket" "react_app" {
+  bucket = "${var.project_name}-react-app-${random_string.bucket_suffix.result}"
+}
+
+resource "random_string" "bucket_suffix" {
+  length  = 8
+  special = false
+  upper   = false
+}
+
+resource "aws_s3_bucket_website_configuration" "react_app" {
+  bucket = aws_s3_bucket.react_app.id
+
+  index_document {
+    suffix = "index.html"
+  }
+
+  error_document {
+    key = "index.html"
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "react_app" {
+  bucket = aws_s3_bucket.react_app.id
+
+  block_public_acls       = false
+  block_public_policy     = false
+  ignore_public_acls      = false
+  restrict_public_buckets = false
+}
+
+resource "aws_s3_bucket_policy" "react_app" {
+  bucket = aws_s3_bucket.react_app.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid       = "PublicReadGetObject"
+        Effect    = "Allow"
+        Principal = "*"
+        Action    = "s3:GetObject"
+        Resource  = "${aws_s3_bucket.react_app.arn}/*"
+      }
+    ]
+  })
+
+  depends_on = [aws_s3_bucket_public_access_block.react_app]
+}
+
+# CloudFront distribution
+resource "aws_cloudfront_distribution" "react_app" {
+  origin {
+    domain_name = aws_s3_bucket_website_configuration.react_app.website_endpoint
+    origin_id   = "S3-${aws_s3_bucket.react_app.bucket}"
+
+    custom_origin_config {
+      http_port              = 80
+      https_port             = 443
+      origin_protocol_policy = "http-only"
+      origin_ssl_protocols   = ["TLSv1.2"]
+    }
+  }
+
+  enabled             = true
+  is_ipv6_enabled     = true
+  default_root_object = "index.html"
+
+  default_cache_behavior {
+    allowed_methods        = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
+    cached_methods         = ["GET", "HEAD"]
+    target_origin_id       = "S3-${aws_s3_bucket.react_app.bucket}"
+    compress               = true
+    viewer_protocol_policy = "redirect-to-https"
+
+    forwarded_values {
+      query_string = false
+      cookies {
+        forward = "none"
+      }
+    }
+
+    min_ttl     = 0
+    default_ttl = 3600
+    max_ttl     = 86400
+  }
+
+  custom_error_response {
+    error_code         = 404
+    response_code      = 200
+    response_page_path = "/index.html"
+  }
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+
+  viewer_certificate {
+    cloudfront_default_certificate = true
+  }
+
+  tags = {
+    Name = "${var.project_name}-cloudfront"
+  }
+}

--- a/2.iac/react_app_deploy/terraform/outputs.tf
+++ b/2.iac/react_app_deploy/terraform/outputs.tf
@@ -1,0 +1,19 @@
+output "s3_bucket_name" {
+  description = "Name of the S3 bucket"
+  value       = aws_s3_bucket.react_app.bucket
+}
+
+output "cloudfront_distribution_id" {
+  description = "CloudFront distribution ID"
+  value       = aws_cloudfront_distribution.react_app.id
+}
+
+output "cloudfront_domain_name" {
+  description = "CloudFront distribution domain name"
+  value       = aws_cloudfront_distribution.react_app.domain_name
+}
+
+output "website_url" {
+  description = "Website URL"
+  value       = "https://${aws_cloudfront_distribution.react_app.domain_name}"
+}

--- a/2.iac/react_app_deploy/terraform/variables.tf
+++ b/2.iac/react_app_deploy/terraform/variables.tf
@@ -1,0 +1,11 @@
+variable "aws_region" {
+  description = "AWS region"
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "project_name" {
+  description = "Project name for resource naming"
+  type        = string
+  default     = "hackathon-react"
+}


### PR DESCRIPTION
## 개요
React 앱을 AWS S3와 CloudFront를 사용해 배포하는 Terraform 인프라 구성을 추가했습니다.

## 주요 변경사항
- S3 버킷을 통한 정적 웹사이트 호스팅
- CloudFront CDN으로 HTTPS 제공
- SPA 라우팅을 위한 404 → index.html 리다이렉트 설정
- 자동 배포/삭제 스크립트 제공

## 배포 방법
```bash
cd 2.iac/react_app_deploy
./deploy.sh
```

## 아키텍처
- **S3**: React 빌드 파일 호스팅
- **CloudFront**: CDN 및 HTTPS 제공
- **자동 캐시 무효화**: 배포 시 자동으로 CloudFront 캐시 갱신