### PR TITLE
Add LangGraph Terraform Deployment Infrastructure

### DIFF
--- a/2.iac/langgraph_deploy/.gitignore
+++ b/2.iac/langgraph_deploy/.gitignore
@@ -1,0 +1,11 @@
+# Terraform
+.terraform/
+*.tfstate
+*.tfstate.*
+*.tfvars
+.terraform.lock.hcl
+.terraform.tfstate.lock.info
+
+# OS
+.DS_Store
+Thumbs.db

--- a/2.iac/langgraph_deploy/README.md
+++ b/2.iac/langgraph_deploy/README.md
@@ -1,0 +1,180 @@
+# LangGraph PRD Generator - AWS 배포
+
+LangGraph PRD 생성 에이전트를 AWS ECS Fargate에 배포하는 Terraform 구성입니다.
+
+## 아키텍처
+
+- **ECS Fargate**: 컨테이너화된 FastAPI 애플리케이션
+- **Application Load Balancer**: HTTP 트래픽 분산
+- **S3**: PRD 파일 저장소
+- **Amazon Bedrock**: Claude 모델 연동
+- **ECR**: Docker 이미지 저장소
+
+## 배포 전 준비사항
+
+### 1. AWS CLI 설정
+```bash
+aws configure
+```
+
+### 2. Terraform 설치
+```bash
+# macOS
+brew install terraform
+
+# 또는 다운로드: https://www.terraform.io/downloads
+```
+
+### 3. Docker 설치
+```bash
+# macOS
+brew install docker
+```
+
+## 배포 방법
+
+### HTTPS 설정 (권장)
+
+도메인이 있는 경우 HTTPS로 배포:
+
+```bash
+# terraform.tfvars 파일 생성
+echo 'domain_name = "api.yourdomain.com"' > terraform/terraform.tfvars
+
+# 배포 실행
+./deploy.sh
+```
+
+**주의:** 도메인의 DNS 설정에서 ACM 인증서 검증을 위한 CNAME 레코드를 추가해야 합니다.
+
+### HTTP 배포 (테스트용)
+
+도메인 없이 HTTP로 배포:
+
+```bash
+./deploy.sh
+```
+
+### 1. 자동 배포 (권장)
+```bash
+./deploy.sh
+```
+
+### 2. 수동 배포
+```bash
+# 1. 인프라 배포
+cd terraform
+terraform init
+terraform apply
+
+# 2. Docker 이미지 빌드 및 푸시
+ECR_REPO=$(terraform output -raw ecr_repository_url)
+cd ../../1.code/langgraph
+
+# Dockerfile 생성 (deploy.sh에서 자동 생성됨)
+docker build --platform linux/amd64 -t langgraph-prd .
+docker tag langgraph-prd:latest $ECR_REPO:latest
+docker push $ECR_REPO:latest
+
+# 3. ECS 서비스 업데이트
+aws ecs update-service \
+    --cluster langgraph-prd-cluster \
+    --service langgraph-prd-service \
+    --force-new-deployment
+```
+
+## 배포 후 확인
+
+### API 엔드포인트
+```bash
+# 로드 밸런서 DNS 확인
+cd terraform
+terraform output load_balancer_dns
+
+# API 테스트
+curl http://<load-balancer-dns>/health
+```
+
+### Swagger UI 접속
+```
+http://<load-balancer-dns>/docs
+```
+
+## API 사용법
+
+### PRD 생성
+```bash
+curl -X POST "http://<load-balancer-dns>/generate-prd" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "conversation_summary": "쇼핑몰 관리자 페이지 개발 요구사항",
+    "image_url": "https://s3.amazonaws.com/bucket/design.png",
+    "html_url": "https://s3.amazonaws.com/bucket/template.html"
+  }'
+```
+
+### PRD 파일 조회
+```bash
+curl "http://<load-balancer-dns>/prd/PRD_20250906_110856.md"
+```
+
+## 환경 변수
+
+배포 시 다음 환경 변수가 자동으로 설정됩니다:
+
+- `AWS_REGION`: us-east-1
+- `BEDROCK_MODEL_ID`: us.anthropic.claude-sonnet-4-20250514-v1:0
+- `MODEL_TEMPERATURE`: 0
+- `MAX_TOKENS`: 4096
+- `DEBUG`: false
+- `LOG_LEVEL`: INFO
+- `S3_BUCKET_NAME`: 자동 생성된 S3 버킷명
+
+## 리소스 정리
+
+```bash
+./destroy.sh
+```
+
+## 비용 예상
+
+**월 예상 비용 (최소 사용량 기준):**
+- ECS Fargate (0.25 vCPU, 0.5GB): ~$10
+- Application Load Balancer: ~$16
+- S3 (1GB 저장): ~$0.02
+- Bedrock API 호출: 사용량에 따라 변동
+- **총 예상: ~$26/월** (Bedrock 제외)
+
+## 문제 해결
+
+### 1. 배포 실패 시
+```bash
+# 로그 확인
+aws logs describe-log-groups --log-group-name-prefix "/ecs/langgraph-prd"
+
+# ECS 서비스 상태 확인
+aws ecs describe-services \
+    --cluster langgraph-prd-cluster \
+    --services langgraph-prd-service
+```
+
+### 2. Bedrock 권한 오류
+- IAM 역할에 `bedrock-runtime:InvokeModel` 권한이 있는지 확인
+- Bedrock 모델이 해당 리전에서 사용 가능한지 확인
+
+### 3. S3 접근 오류
+- IAM 역할에 S3 버킷 권한이 있는지 확인
+- 버킷 정책 확인
+
+## 보안 고려사항
+
+- ECS Task Role을 통한 AWS 서비스 접근 (하드코딩된 자격증명 없음)
+- S3 버킷 퍼블릭 액세스 차단
+- VPC 내 프라이빗 서브넷 사용 가능 (필요 시)
+- ALB를 통한 HTTPS 설정 가능 (도메인 있을 시)
+
+## 모니터링
+
+- **CloudWatch Logs**: `/ecs/langgraph-prd-app`
+- **ECS 메트릭**: CPU, 메모리 사용률
+- **ALB 메트릭**: 요청 수, 응답 시간

--- a/2.iac/langgraph_deploy/deploy.sh
+++ b/2.iac/langgraph_deploy/deploy.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+
+# 변수 설정
+PROJECT_NAME="langgraph-prd"
+AWS_REGION="us-east-1"
+AWS_ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
+APP_DIR="../../1.code/langgraph"
+
+echo "🚀 Starting LangGraph deployment process..."
+
+# 1. Terraform 인프라 배포
+echo "📦 Deploying infrastructure with Terraform..."
+cd terraform
+terraform init
+terraform plan
+terraform apply -auto-approve
+
+# ECR 리포지토리 URL 가져오기
+ECR_REPO=$(terraform output -raw ecr_repository_url)
+cd ..
+
+# 2. Docker 이미지 빌드 및 푸시
+echo "🐳 Building and pushing Docker image..."
+
+# ECR 로그인
+aws ecr get-login-password --region $AWS_REGION | docker login --username AWS --password-stdin $ECR_REPO
+
+# Dockerfile 생성 (LangGraph 프로젝트용)
+cat > $APP_DIR/Dockerfile << 'EOF'
+FROM python:3.11-slim
+
+WORKDIR /app
+
+# 시스템 패키지 설치
+RUN apt-get update && apt-get install -y \
+    gcc \
+    && rm -rf /var/lib/apt/lists/*
+
+# Python 의존성 설치
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+# 애플리케이션 코드 복사
+COPY . .
+
+# 출력 디렉토리 생성
+RUN mkdir -p prd_outputs
+
+# 포트 노출
+EXPOSE 8000
+
+# 애플리케이션 실행
+CMD ["python", "main.py"]
+EOF
+
+# Docker 이미지 빌드 (x86_64 플랫폼용)
+cd $APP_DIR
+docker build --platform linux/amd64 -t $PROJECT_NAME .
+docker tag $PROJECT_NAME:latest $ECR_REPO:latest
+
+# ECR에 푸시
+docker push $ECR_REPO:latest
+
+# 3. ECS 서비스 업데이트
+echo "🔄 Updating ECS service..."
+aws ecs update-service \
+    --cluster ${PROJECT_NAME}-cluster \
+    --service ${PROJECT_NAME}-service \
+    --force-new-deployment \
+    --region $AWS_REGION
+
+echo "✅ Deployment completed!"
+echo "🌐 HTTPS API endpoint: $(cd ../../2.iac/langgraph_deploy/terraform && terraform output -raw api_endpoint)"
+echo "📚 API Documentation: $(cd ../../2.iac/langgraph_deploy/terraform && terraform output -raw api_endpoint)/docs"
+echo ""
+echo "📋 Available endpoints:"
+echo "  HTTPS (CloudFront): $(cd ../../2.iac/langgraph_deploy/terraform && terraform output -raw api_endpoint)"
+echo "  HTTP (ALB Direct):  $(cd ../../2.iac/langgraph_deploy/terraform && terraform output -raw http_endpoint)"

--- a/2.iac/langgraph_deploy/destroy.sh
+++ b/2.iac/langgraph_deploy/destroy.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+PROJECT_NAME="langgraph-prd"
+AWS_REGION="us-east-1"
+
+echo "🗑️  Starting resource cleanup..."
+
+# 1. ECS 서비스 스케일 다운
+echo "📉 Scaling down ECS service..."
+aws ecs update-service \
+    --cluster ${PROJECT_NAME}-cluster \
+    --service ${PROJECT_NAME}-service \
+    --desired-count 0 \
+    --region $AWS_REGION
+
+# 2. Terraform 리소스 삭제
+echo "🔥 Destroying infrastructure with Terraform..."
+cd terraform
+terraform destroy -auto-approve
+cd ..
+
+echo "✅ Cleanup completed!"

--- a/2.iac/langgraph_deploy/terraform/cloudfront.tf
+++ b/2.iac/langgraph_deploy/terraform/cloudfront.tf
@@ -1,0 +1,74 @@
+# CloudFront Distribution for HTTPS
+resource "aws_cloudfront_distribution" "main" {
+  origin {
+    domain_name = aws_lb.main.dns_name
+    origin_id   = "ALB-${var.project_name}"
+
+    custom_origin_config {
+      http_port                = 80
+      https_port               = 443
+      origin_protocol_policy   = "http-only"
+      origin_ssl_protocols     = ["TLSv1.2"]
+      origin_read_timeout      = 180
+      origin_keepalive_timeout = 5
+    }
+  }
+
+  enabled = true
+
+  default_cache_behavior {
+    allowed_methods        = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
+    cached_methods         = ["GET", "HEAD"]
+    target_origin_id       = "ALB-${var.project_name}"
+    compress               = true
+    viewer_protocol_policy = "redirect-to-https"
+
+    forwarded_values {
+      query_string = true
+      headers      = ["*"]
+      cookies {
+        forward = "all"
+      }
+    }
+
+    min_ttl     = 0
+    default_ttl = 0
+    max_ttl     = 0
+  }
+
+  # API 경로별 캐시 동작 설정
+  ordered_cache_behavior {
+    path_pattern     = "/generate-prd"
+    allowed_methods  = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
+    cached_methods   = ["GET", "HEAD"]
+    target_origin_id = "ALB-${var.project_name}"
+    compress         = true
+    viewer_protocol_policy = "redirect-to-https"
+
+    forwarded_values {
+      query_string = true
+      headers      = ["*"]
+      cookies {
+        forward = "all"
+      }
+    }
+
+    min_ttl     = 0
+    default_ttl = 0
+    max_ttl     = 0
+  }
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+
+  viewer_certificate {
+    cloudfront_default_certificate = true
+  }
+
+  tags = {
+    Name = "${var.project_name}-cloudfront"
+  }
+}

--- a/2.iac/langgraph_deploy/terraform/iam.tf
+++ b/2.iac/langgraph_deploy/terraform/iam.tf
@@ -1,0 +1,85 @@
+# ECS Execution Role
+resource "aws_iam_role" "ecs_execution_role" {
+  name = "${var.project_name}-ecs-execution-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Principal = {
+          Service = "ecs-tasks.amazonaws.com"
+        }
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "ecs_execution_role_policy" {
+  role       = aws_iam_role.ecs_execution_role.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+}
+
+# ECS Task Role
+resource "aws_iam_role" "ecs_task_role" {
+  name = "${var.project_name}-ecs-task-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Principal = {
+          Service = "ecs-tasks.amazonaws.com"
+        }
+      }
+    ]
+  })
+}
+
+# Bedrock 권한
+resource "aws_iam_role_policy" "bedrock_policy" {
+  name = "${var.project_name}-bedrock-policy"
+  role = aws_iam_role.ecs_task_role.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "bedrock-runtime:InvokeModel",
+          "bedrock-runtime:InvokeModelWithResponseStream"
+        ]
+        Resource = "*"
+      }
+    ]
+  })
+}
+
+# S3 권한
+resource "aws_iam_role_policy" "s3_policy" {
+  name = "${var.project_name}-s3-policy"
+  role = aws_iam_role.ecs_task_role.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "s3:GetObject",
+          "s3:PutObject",
+          "s3:DeleteObject",
+          "s3:ListBucket"
+        ]
+        Resource = [
+          aws_s3_bucket.prd_files.arn,
+          "${aws_s3_bucket.prd_files.arn}/*"
+        ]
+      }
+    ]
+  })
+}

--- a/2.iac/langgraph_deploy/terraform/main.tf
+++ b/2.iac/langgraph_deploy/terraform/main.tf
@@ -1,0 +1,259 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+    tls = {
+      source  = "hashicorp/tls"
+      version = "~> 4.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+}
+
+# VPC 및 네트워킹
+resource "aws_vpc" "main" {
+  cidr_block           = "10.0.0.0/16"
+  enable_dns_hostnames = true
+  enable_dns_support   = true
+
+  tags = {
+    Name = "${var.project_name}-vpc"
+  }
+}
+
+resource "aws_internet_gateway" "main" {
+  vpc_id = aws_vpc.main.id
+
+  tags = {
+    Name = "${var.project_name}-igw"
+  }
+}
+
+resource "aws_subnet" "public" {
+  count             = 2
+  vpc_id            = aws_vpc.main.id
+  cidr_block        = "10.0.${count.index + 1}.0/24"
+  availability_zone = data.aws_availability_zones.available.names[count.index]
+  
+  map_public_ip_on_launch = true
+
+  tags = {
+    Name = "${var.project_name}-public-subnet-${count.index + 1}"
+  }
+}
+
+resource "aws_route_table" "public" {
+  vpc_id = aws_vpc.main.id
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.main.id
+  }
+
+  tags = {
+    Name = "${var.project_name}-public-rt"
+  }
+}
+
+resource "aws_route_table_association" "public" {
+  count          = length(aws_subnet.public)
+  subnet_id      = aws_subnet.public[count.index].id
+  route_table_id = aws_route_table.public.id
+}
+
+# Security Groups
+resource "aws_security_group" "app" {
+  name_prefix = "${var.project_name}-app-"
+  vpc_id      = aws_vpc.main.id
+
+  ingress {
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    from_port   = 8000
+    to_port     = 8000
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name = "${var.project_name}-app-sg"
+  }
+}
+
+# ECS Cluster
+resource "aws_ecs_cluster" "main" {
+  name = "${var.project_name}-cluster"
+
+  setting {
+    name  = "containerInsights"
+    value = "enabled"
+  }
+}
+
+# ECR Repository
+resource "aws_ecr_repository" "app" {
+  name = "${var.project_name}-app"
+}
+
+# CloudWatch Log Group
+resource "aws_cloudwatch_log_group" "app" {
+  name              = "/ecs/${var.project_name}-app"
+  retention_in_days = 7
+}
+
+# ECS Task Definition
+resource "aws_ecs_task_definition" "app" {
+  family                   = "${var.project_name}-app"
+  network_mode             = "awsvpc"
+  requires_compatibilities = ["FARGATE"]
+  cpu                      = "256"
+  memory                   = "512"
+  execution_role_arn       = aws_iam_role.ecs_execution_role.arn
+  task_role_arn           = aws_iam_role.ecs_task_role.arn
+
+  container_definitions = jsonencode([
+    {
+      name  = "app"
+      image = "${aws_ecr_repository.app.repository_url}:latest"
+      
+      portMappings = [
+        {
+          containerPort = 8000
+          protocol      = "tcp"
+        }
+      ]
+
+      environment = [
+        {
+          name  = "AWS_REGION"
+          value = var.aws_region
+        },
+        {
+          name  = "BEDROCK_MODEL_ID"
+          value = var.bedrock_model_id
+        },
+        {
+          name  = "MODEL_TEMPERATURE"
+          value = var.model_temperature
+        },
+        {
+          name  = "MAX_TOKENS"
+          value = var.max_tokens
+        },
+        {
+          name  = "DEBUG"
+          value = var.debug_mode
+        },
+        {
+          name  = "LOG_LEVEL"
+          value = var.log_level
+        },
+        {
+          name  = "S3_BUCKET_NAME"
+          value = aws_s3_bucket.prd_files.bucket
+        }
+      ]
+
+      logConfiguration = {
+        logDriver = "awslogs"
+        options = {
+          awslogs-group         = aws_cloudwatch_log_group.app.name
+          awslogs-region        = var.aws_region
+          awslogs-stream-prefix = "ecs"
+        }
+      }
+    }
+  ])
+}
+
+# Application Load Balancer
+resource "aws_lb" "main" {
+  name               = "${var.project_name}-alb"
+  internal           = false
+  load_balancer_type = "application"
+  security_groups    = [aws_security_group.app.id]
+  subnets           = aws_subnet.public[*].id
+}
+
+resource "aws_lb_target_group" "app" {
+  name        = "${var.project_name}-tg"
+  port        = 8000
+  protocol    = "HTTP"
+  vpc_id      = aws_vpc.main.id
+  target_type = "ip"
+
+  health_check {
+    enabled             = true
+    healthy_threshold   = 2
+    interval            = 30
+    matcher             = "200"
+    path                = "/health"
+    port                = "traffic-port"
+    protocol            = "HTTP"
+    timeout             = 10
+    unhealthy_threshold = 3
+  }
+}
+
+# HTTP Listener
+resource "aws_lb_listener" "app" {
+  load_balancer_arn = aws_lb.main.arn
+  port              = "80"
+  protocol          = "HTTP"
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.app.arn
+  }
+}
+
+# ECS Service
+resource "aws_ecs_service" "app" {
+  name            = "${var.project_name}-service"
+  cluster         = aws_ecs_cluster.main.id
+  task_definition = aws_ecs_task_definition.app.arn
+  desired_count   = 1
+  launch_type     = "FARGATE"
+
+  network_configuration {
+    security_groups  = [aws_security_group.app.id]
+    subnets         = aws_subnet.public[*].id
+    assign_public_ip = true
+  }
+
+  load_balancer {
+    target_group_arn = aws_lb_target_group.app.arn
+    container_name   = "app"
+    container_port   = 8000
+  }
+
+  depends_on = [aws_lb_listener.app]
+}
+
+data "aws_availability_zones" "available" {
+  state = "available"
+}

--- a/2.iac/langgraph_deploy/terraform/outputs.tf
+++ b/2.iac/langgraph_deploy/terraform/outputs.tf
@@ -1,0 +1,39 @@
+output "load_balancer_dns" {
+  description = "DNS name of the load balancer"
+  value       = aws_lb.main.dns_name
+}
+
+output "cloudfront_domain" {
+  description = "CloudFront distribution domain name"
+  value       = aws_cloudfront_distribution.main.domain_name
+}
+
+output "api_endpoint" {
+  description = "API endpoint URL (HTTPS via CloudFront)"
+  value       = "https://${aws_cloudfront_distribution.main.domain_name}"
+}
+
+output "http_endpoint" {
+  description = "HTTP endpoint URL (ALB direct)"
+  value       = "http://${aws_lb.main.dns_name}"
+}
+
+output "ecr_repository_url" {
+  description = "ECR repository URL"
+  value       = aws_ecr_repository.app.repository_url
+}
+
+output "s3_bucket_name" {
+  description = "S3 bucket name for PRD files"
+  value       = aws_s3_bucket.prd_files.bucket
+}
+
+output "ecs_cluster_name" {
+  description = "ECS cluster name"
+  value       = aws_ecs_cluster.main.name
+}
+
+output "ecs_service_name" {
+  description = "ECS service name"
+  value       = aws_ecs_service.app.name
+}

--- a/2.iac/langgraph_deploy/terraform/s3.tf
+++ b/2.iac/langgraph_deploy/terraform/s3.tf
@@ -1,0 +1,39 @@
+# S3 Bucket for PRD files
+resource "aws_s3_bucket" "prd_files" {
+  bucket = "${var.project_name}-prd-files-${random_string.bucket_suffix.result}"
+}
+
+resource "random_string" "bucket_suffix" {
+  length  = 8
+  special = false
+  upper   = false
+}
+
+# S3 Bucket versioning
+resource "aws_s3_bucket_versioning" "prd_files" {
+  bucket = aws_s3_bucket.prd_files.id
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+# S3 Bucket encryption
+resource "aws_s3_bucket_server_side_encryption_configuration" "prd_files" {
+  bucket = aws_s3_bucket.prd_files.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+# S3 Bucket public access block
+resource "aws_s3_bucket_public_access_block" "prd_files" {
+  bucket = aws_s3_bucket.prd_files.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}

--- a/2.iac/langgraph_deploy/terraform/variables.tf
+++ b/2.iac/langgraph_deploy/terraform/variables.tf
@@ -1,0 +1,47 @@
+variable "aws_region" {
+  description = "AWS region"
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "project_name" {
+  description = "Project name for resource naming"
+  type        = string
+  default     = "langgraph-prd"
+}
+
+variable "bedrock_model_id" {
+  description = "Bedrock model ID for Claude"
+  type        = string
+  default     = "us.anthropic.claude-sonnet-4-20250514-v1:0"
+}
+
+variable "model_temperature" {
+  description = "Model temperature setting"
+  type        = string
+  default     = "0"
+}
+
+variable "max_tokens" {
+  description = "Maximum tokens for model response"
+  type        = string
+  default     = "4096"
+}
+
+variable "debug_mode" {
+  description = "Debug mode setting"
+  type        = string
+  default     = "false"
+}
+
+variable "log_level" {
+  description = "Logging level"
+  type        = string
+  default     = "INFO"
+}
+
+variable "domain_name" {
+  description = "Domain name for the application"
+  type        = string
+  default     = ""
+}


### PR DESCRIPTION
## 🚀 LangGraph PRD Generator AWS 배포 인프라

LangGraph PRD 생성 에이전트를 AWS에 배포하기 위한 완전한 Terraform 인프라를 추가했습니다.

### 📋 주요 변경사항

#### 새로운 파일들
- `2.iac/langgraph_deploy/` - 전체 배포 구조
- `terraform/` - AWS 인프라 코드
- `deploy.sh` / `destroy.sh` - 원클릭 배포/정리 스크립트
- `README.md` - 상세 배포 가이드

#### 아키텍처
- **ECS Fargate**: 서버리스 컨테이너 (256 CPU, 512MB 메모리)
- **Application Load Balancer**: HTTP 트래픽 분산
- **CloudFront**: HTTPS 지원 + 글로벌 CDN (180초 타임아웃)
- **S3**: PRD 파일 영구 저장소
- **IAM**: Bedrock + S3 권한 설정

### 🔧 기술적 특징

#### HTTPS 지원
- CloudFront를 통한 자동 HTTPS 제공
- 도메인 없이도 SSL 인증서 사용 가능
- HTTP → HTTPS 자동 리다이렉트

#### Bedrock 연동
- ECS Task Role을 통한 안전한 권한 관리
- 하드코딩된 AWS 자격증명 없음
- 180초 타임아웃으로 긴 AI 처리 시간 지원

#### 환경 변수 처리
- 로컬: `.env` 파일 사용
- 배포: ECS Task Definition 환경 변수
- Bedrock 모델 ID, 온도 등 설정 가능

### 🚀 배포 방법

```bash
cd 2.iac/langgraph_deploy
./deploy.sh
```

### 📊 예상 비용
- **월 ~$26** (Bedrock API 호출 제외)
- ECS Fargate: ~$10
- ALB: ~$16
- S3: ~$0.02

### 🧪 테스트 완료
- ✅ ALB 직접 접근 테스트 통과
- ✅ Bedrock API 호출 정상 (40초 처리시간)
- ✅ PRD 파일 생성 성공
- ✅ CloudFront 타임아웃 설정 완료

### 🔗 관련 이슈
- CloudFront 504 Gateway Timeout 해결
- Bedrock API 긴 처리시간 대응
- HTTPS 자동 배포 지원

이제 LangGraph API를 AWS에 완전히 배포하여 HTTPS로 안전하게 접근할 수 있습니다!